### PR TITLE
refactoring : 부서 목록 조회 시 정렬 및 페이지네이션 일관성 개선

### DIFF
--- a/src/main/java/com/codeit/sb01hrbankteam04/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/codeit/sb01hrbankteam04/domain/department/repository/DepartmentRepository.java
@@ -34,14 +34,16 @@ public interface DepartmentRepository extends JpaRepository<Department, Long> {
 
 
   @Query("""
-          SELECT d FROM Department d
-          WHERE (:nameOrDescription IS NULL 
-              OR d.name LIKE %:nameOrDescription% 
-              OR d.description LIKE %:nameOrDescription%)
-          AND (:idAfter IS NULL OR d.id > :idAfter)
-      """)
+    SELECT d FROM Department d
+    WHERE (:nameOrDescription IS NULL 
+        OR d.name LIKE %:nameOrDescription% 
+        OR d.description LIKE %:nameOrDescription%)
+    AND (:idAfter IS NULL OR d.id > :idAfter)
+""")
   List<Department> findDepartmentsByCursor(
-      @Param("nameOrDescription") String nameOrDescription,
-      @Param("idAfter") Long idAfter,
-      Pageable pageable);
+          @Param("nameOrDescription") String nameOrDescription,
+          @Param("idAfter") Long idAfter,
+          Pageable pageable
+  );
+
 }


### PR DESCRIPTION
-정렬 방식 통일 (오름차순/ 내림차순)
-커서 기반 페이지네이션 적용 정렬 변경은 cursor 값유지

## #️⃣ 연관 이슈

> #21 

### 🎯 PR 개요

- 정렬 방식 통일 (오름차순/내림차순 처리 방식 통일)
- 커서 기반 페이지네이션 적용 시, 정렬만 변경할 경우 cursor 값 유지

### 📑 작업 내용

- 정렬 방식 통일 (오름차순/내림차순 처리 방식 통일)
- 커서 기반 페이지네이션 적용 시, 정렬만 변경할 경우 cursor 값 유지

#### 🛠 테스트 내용 (선택)

> 변경 사항을 어떻게 테스트했는지 설명해주세요.
> (예: 유닛 테스트, 통합 테스트 등)

### 📝 참고 사항 (선택)

> 관련된 이슈, 문서 또는 추가 설명이 필요하면 작성해주세요.

### 💬리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.